### PR TITLE
Fix handling of CLI arguments in the tools (-T) mode

### DIFF
--- a/scripts/remount-proc-exec
+++ b/scripts/remount-proc-exec
@@ -7,4 +7,4 @@ umount /proc
 mount -t proc proc /proc
 
 # Exec command
-exec $@
+exec "$@"


### PR DESCRIPTION
Currently, kpexec performs word splitting and path expansion on arguments passed to the command if the `tools` mode is enabled:

```
$ kubectl pexec -T -it -n kube-system calico-node-6bzl6 -- printf '%s\n' '1 2' 'b*'
Defaulting container name to calico-node.
Create cnsenter pod (cnsenter-pbjg9di1n4)
Wait to run cnsenter pod (cnsenter-pbjg9di1n4)
1
2
bin
boot
Delete cnsenter pod (cnsenter-pbjg9di1n4)
```

This does not happen without the tools mode:

```
$ kubectl pexec -n kube-system calico-node-6bzl6 -- printf '%s\n' '1 2' 'b*'
Defaulting container name to calico-node.
Create cnsenter pod (cnsenter-8o0g65iwa5)
Wait to run cnsenter pod (cnsenter-8o0g65iwa5)
1 2
b*
Delete cnsenter pod (cnsenter-8o0g65iwa5)
```

The reason is an unquoted `$@` construct in the scripts/remount-proc-exec file - by quoting it as `"$@"` the tools mode will behave in the same way as the non-tools mode.
