### PR TITLE
Correct crictl binary for ARM64 in Dockerfiles

### DIFF
--- a/Dockerfile-cnsenter
+++ b/Dockerfile-cnsenter
@@ -9,9 +9,9 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags="-X 'github.com/ssup2/kpex
 FROM alpine:3.13.1 as downloader
 ARG TARGETPLATFORM
 ENV CRICTL_VERSION v1.24.1
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm; else ARCHITECTURE=amd64; fi \  
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \  
     && wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCHITECTURE}.tar.gz
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm; else ARCHITECTURE=amd64; fi \  
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \  
     && tar zxvf crictl-${CRICTL_VERSION}-linux-${ARCHITECTURE}.tar.gz -C /usr/local/bin
 
 # Build image

--- a/Dockerfile-cnsenter-tools
+++ b/Dockerfile-cnsenter-tools
@@ -9,9 +9,9 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags="-X 'github.com/ssup2/kpex
 FROM alpine:3.13.1 as downloader
 ARG TARGETPLATFORM
 ENV CRICTL_VERSION v1.24.1
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm; else ARCHITECTURE=amd64; fi \
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \
     && wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCHITECTURE}.tar.gz
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm; else ARCHITECTURE=amd64; fi \
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \
     && tar zxvf crictl-${CRICTL_VERSION}-linux-${ARCHITECTURE}.tar.gz -C /usr/local/bin
 
 # Build image


### PR DESCRIPTION
The current Dockerfiles reference `crictl-v1.24.1-linux-arm.tar.gz` for arm64 builds whereas this should be: `crictl-v1.24.1-linux-arm64.tar.gz`

This results in an Exec format error when starting the container on a GCP C4A (ARM64) Node.

This commit corrects the incorrect crictl being downloaded.